### PR TITLE
Elementalized directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Autocomplete directive for Angular that supports configurable event handling and
 
 ## Usage example:
 ```javascript
-    <autocomplete ng-model="data" query-suggestions="autocompleteQuery" on-selection-complete="onSelectionComplete"></autocomplete>
+<autocomplete ng-model="data" query-suggestions="autocompleteQuery" on-selection-complete="onSelectionComplete"></autocomplete>
 ```
 
 ## Attribtues

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Autocomplete directive for Angular that supports configurable event handling and templates.
 
 ## Usage example:
-```javascript
+```html
 <autocomplete ng-model="data" query-suggestions="autocompleteQuery" on-selection-complete="onSelectionComplete"></autocomplete>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # angular-autocomplete
 Autocomplete directive for Angular that supports configurable event handling and templates.
+
+## Usage example:
+```javascript
+    <autocomplete ng-model="data" query-suggestions="autocompleteQuery" on-selection-complete="onSelectionComplete"></autocomplete>
+```
+
+## Attribtues
+`ng-model`: *(required)* The data model that autocomplete will be using to fetch suggestions. Idealy tied to the model of an input field.
+
+`query-suggestions`: *(required)* A callback function that takes one argument as the input value and produces a list of autocomplete suggestions.
+
+`on-selection-complete`: *(optional)* A callback function that gets invoked once interaction of the autocomplete widget is completed, either by selecting a value or dismissed by key press. If a value is selected this function will receive the value as a parameter, otherwise it will receive `null`. This is a good place to handle focus event, be it restoring focus on the original input element for further input, or passing along to the next input element in the form.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Autocomplete directive for Angular that supports configurable event handling and
 ## Attribtues
 `ng-model`: *(required)* The data model that autocomplete will be using to fetch suggestions. Idealy tied to the model of an input field.
 
-`query-suggestions`: *(required)* A callback function that takes one argument as the input value and produces a list of autocomplete suggestions.
+`query-suggestions`: *(required)* A callback function that takes one argument as the input value and produces a list of autocomplete suggestions. Autocomplete will call this function with its model when the model changes.
 
 `on-selection-complete`: *(optional)* A callback function that gets invoked once interaction of the autocomplete widget is completed, either by selecting a value or dismissed by key press. If a value is selected this function will receive the value as a parameter, otherwise it will receive `null`. This is a good place to handle focus event, be it restoring focus on the original input element for further input, or passing along to the next input element in the form.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ Autocomplete directive for Angular that supports configurable event handling and
 `query-suggestions`: *(required)* A callback function that takes one argument as the input value and produces a list of autocomplete suggestions. Autocomplete will call this function with its model when the model changes.
 
 `on-selection-complete`: *(optional)* A callback function that gets invoked once interaction of the autocomplete widget is completed, either by selecting a value or dismissed by key press. If a value is selected this function will receive the value as a parameter, otherwise it will receive `null`. This is a good place to handle focus event, be it restoring focus on the original input element for further input, or passing along to the next input element in the form.
+
+## Keypress handling
+Autocomplete includes basic keypress handling, provided it has focus. Broadcast a `autocompleteFocus` event from the parent scope for it to capture focus and start keyboard interactions.
+
+`Up Arrow`: hightlight previous item
+
+`Down Arrow`: hightlight next item
+
+`Enter/Tab`: select current item (this will trigger `on-selection-complete` callback with the value selected as the parameter)
+
+`Esc`: dismiss without selecting (this will trigger `on-selection-complete` callback with a `null` parameter)

--- a/angular-autocomplete.css
+++ b/angular-autocomplete.css
@@ -23,7 +23,3 @@
 .angular-autocomplete > ._suggestions > ._suggestion.-selected {
     background: #e0e0e0;
 }
-
-.angular-autocomplete > ._suggestions > ._suggestion:hover {
-    background: #eee;
-}

--- a/angular-autocomplete.css
+++ b/angular-autocomplete.css
@@ -8,6 +8,9 @@
     max-width: 100%;
 }
 
+.angular-autocomplete:focus {
+    outline: none;
+}
 
 .angular-autocomplete > ._suggestions {
     list-style: none;

--- a/angular-autocomplete.js
+++ b/angular-autocomplete.js
@@ -45,22 +45,22 @@
                     querySuggestions: '='
                 },
 
-                link: function ($scope, $element, $attributes, ngModel) {
-                    $scope.matches = []
-                    $scope.selectedIndex = -1;
+                link: function (scope, element, attributes, ngModel) {
+                    scope.matches = []
+                    scope.selectedIndex = -1;
 
                     var resetMatches = function () {
-                        $scope.matches = [];
-                        $scope.selectedIndex = -1;
+                        scope.matches = [];
+                        scope.selectedIndex = -1;
                     };
 
-                    $scope.isOpen = function () {
-                        return $scope.matches.length > 0;
+                    scope.isOpen = function () {
+                        return scope.matches.length > 0;
                     };
 
-                    $scope.select = function (selectedIndex) {
+                    scope.select = function (selectedIndex) {
                         // called from within the $digest() cycle
-                        var selectedValue = $scope.matches[selectedIndex];
+                        var selectedValue = scope.matches[selectedIndex];
                         ngModel.$setViewValue(selectedValue);
                         ngModel.$render();
 
@@ -68,24 +68,24 @@
 
                         // notify observer of selection complete
                         // this is a good chance to restore focus on whatever element that triggered autocomplete
-                        if ($scope.onSelectionComplete) {
-                            $scope.onSelectionComplete({ value: selectedValue })();
+                        if (scope.onSelectionComplete) {
+                            scope.onSelectionComplete({ value: selectedValue })();
                         }
                     };
 
-                    $scope.selectNext = function () {
-                        $scope.selectedIndex = ($scope.selectedIndex + 1) % $scope.matches.length;
+                    scope.selectNext = function () {
+                        scope.selectedIndex = (scope.selectedIndex + 1) % scope.matches.length;
                     };
 
-                    $scope.selectPrev = function () {
-                        $scope.selectedIndex = ($scope.selectedIndex > 0
-                                                ? $scope.selectedIndex
-                                                : $scope.matches.length) - 1;
+                    scope.selectPrev = function () {
+                        scope.selectedIndex = (scope.selectedIndex > 0
+                                                ? scope.selectedIndex
+                                                : scope.matches.length) - 1;
                     };
 
-                    $scope.setSelectedIndex = function(index) {
-                        if ($scope.selectedIndex !== index) {
-                            $scope.selectedIndex = index;
+                    scope.setSelectedIndex = function(index) {
+                        if (scope.selectedIndex !== index) {
+                            scope.selectedIndex = index;
                         }
                     };
 
@@ -96,53 +96,53 @@
                     ngModel.$formatters.unshift(function (inputValue) {
                         // @todo: add debouncing
                         // 2. Fetch suggestions
-                        $scope.querySuggestions(inputValue).then(function (suggestions) {
+                        scope.querySuggestions(inputValue).then(function (suggestions) {
                             // 3. Present suggestions
-                            $scope.matches = suggestions;
+                            scope.matches = suggestions;
                         });
                     });
 
-                    $scope.$on('autocompleteFocus', function () {
-                        $element[0].focus();
-                        $scope.selectedIndex = 0;
+                    scope.$on('autocompleteFocus', function () {
+                        element[0].focus();
+                        scope.selectedIndex = 0;
                     });
 
                     // 4. Handle mouse selection or keypresses
-                    $element.bind('keydown', function (evt) {
+                    element.bind('keydown', function (evt) {
                         // we have matches and an "interesting" key was pressed
-                        if ($scope.matches.length === 0 || HOT_KEYS.indexOf(evt.which) === -1) {
+                        if (scope.matches.length === 0 || HOT_KEYS.indexOf(evt.which) === -1) {
                             return;
                         }
 
                         // if there's nothing selected and enter/tab is hit, don't do anything
-                        if ($scope.selectedIndex == -1 && (evt.which === 13 || evt.which === 9)) {
+                        if (scope.selectedIndex == -1 && (evt.which === 13 || evt.which === 9)) {
                             return;
                         }
 
                         evt.preventDefault();
 
-                        $scope.$apply(function () {
+                        scope.$apply(function () {
                             if (evt.which === 40) { // Down Arrow
-                                $scope.selectNext();
+                                scope.selectNext();
                             } else if (evt.which === 38) { // Up Arrow
-                                $scope.selectPrev();
+                                scope.selectPrev();
                             } else if (evt.which === 13 || evt.which === 9) { // Enter or Tab
-                                $scope.select($scope.selectedIndex);
+                                scope.select(scope.selectedIndex);
                             } else if (evt.which === 27) { // Esc
                                 // 5. Handle cancelling of the dialog
                                 resetMatches();
                                 evt.stopPropagation();
 
                                 // null indicating no value is selected, again a good chance to restore focus on whatever element that triggered autocomplete
-                                if ($scope.onSelectionComplete) {
-                                    $scope.onSelectionComplete({ value: null })();
+                                if (scope.onSelectionComplete) {
+                                    scope.onSelectionComplete({ value: null })();
                                 }
                             }
                         });
                     }).bind('blur', function () {
-                        if ($scope.matches.length) {
+                        if (scope.matches.length) {
                             // Close the autocomplete dialog when the element loses focus
-                            $scope.$apply(function () {
+                            scope.$apply(function () {
                                 resetMatches();
                             });
                         }

--- a/angular-autocomplete.js
+++ b/angular-autocomplete.js
@@ -64,19 +64,13 @@
                         ngModel.$setViewValue(selectedValue);
                         ngModel.$render();
 
+                        resetMatches();
+
                         // notify observer of selection complete
                         // this is a good chance to restore focus on whatever element that triggered autocomplete
                         if ($scope.onSelectionComplete) {
                             $scope.onSelectionComplete(selectedValue);
                         }
-
-                        // return focus to the input element if a match was selected via a mouse click event
-                        // use timeout to ensure that we reset after all ngmodel related
-                        // changes are handled
-                        $timeout(function () {
-                            resetMatches();
-                            $element[0].focus();
-                        }, 0);
                     };
 
                     $scope.selectNext = function () {
@@ -136,20 +130,22 @@
                                 $scope.select($scope.selectedIndex);
                             } else if (evt.which === 27) { // Esc
                                 // 5. Handle cancelling of the dialog
+                                resetMatches();
+                                evt.stopPropagation();
+
                                 // null indicating no value is selected, again a good chance to restore focus on whatever element that triggered autocomplete
                                 if ($scope.onSelectionComplete) {
                                     $scope.onSelectionComplete(null);
                                 }
-
-                                resetMatches();
-                                evt.stopPropagation();
                             }
                         });
                     }).bind('blur', function () {
-                        // Close the autocomplete dialog when the element loses focus
-                        $scope.$apply(function () {
-                            resetMatches();
-                        });
+                        if ($scope.matches.length) {
+                            // Close the autocomplete dialog when the element loses focus
+                            $scope.$apply(function () {
+                                resetMatches();
+                            });
+                        }
                     });
                 }
             };

--- a/angular-autocomplete.js
+++ b/angular-autocomplete.js
@@ -41,7 +41,7 @@
                 replace: true,
                 require: 'ngModel',
                 scope: {
-                    onSelectionComplete: '=',
+                    onSelectionComplete: '&',
                     querySuggestions: '='
                 },
 
@@ -69,7 +69,7 @@
                         // notify observer of selection complete
                         // this is a good chance to restore focus on whatever element that triggered autocomplete
                         if ($scope.onSelectionComplete) {
-                            $scope.onSelectionComplete(selectedValue);
+                            $scope.onSelectionComplete({ value: selectedValue })();
                         }
                     };
 
@@ -135,7 +135,7 @@
 
                                 // null indicating no value is selected, again a good chance to restore focus on whatever element that triggered autocomplete
                                 if ($scope.onSelectionComplete) {
-                                    $scope.onSelectionComplete(null);
+                                    $scope.onSelectionComplete({ value: null })();
                                 }
                             }
                         });

--- a/angular-autocomplete.js
+++ b/angular-autocomplete.js
@@ -18,8 +18,11 @@
     return angular.module('mp.autocomplete', []).directive('autocomplete', [
         '$window', '$q', '$compile', '$parse', '$timeout',
         function($window, $q, $compile, $parse, $timeout) {
+            // Introduce custom elements for IE8
+            $window.document.createElement('autocomplete');
+
             var TEMPLATE = '' +
-                '<div class="angular-autocomplete" ng-if="isOpen()">' +
+                '<div class="angular-autocomplete" ng-show="isOpen()">' +
                 '  <ul class="_suggestions">' +
                 '    <li ng-repeat="match in matches" ' +
                 '        class="_suggestion"' +
@@ -32,12 +35,15 @@
             var HOT_KEYS = [9, 13, 27, 38, 40];
 
             return {
-                restrict: 'A',
+                restrict: 'E',
+                template: TEMPLATE,
+                replace: true,
                 require: 'ngModel',
                 scope: {
-                    onSuggestionSelected: '&',
-                    autocomplete: '='
+                    onSuggestionSelected: '=',
+                    querySuggestions: '='
                 },
+
                 link: function ($scope, $element, $attributes, ngModel) {
                     var resetMatches = function () {
                         $scope.matches = [];
@@ -80,10 +86,10 @@
                     resetMatches();
 
                     // 1. Watch model for changes
-                    ngModel.$parsers.unshift(function (inputValue) {
+                    ngModel.$formatters.unshift(function (inputValue) {
                         // @todo: add debouncing
                         // 2. Fetch suggestions
-                        $scope.autocomplete(inputValue).then(function (suggestions) {
+                        $scope.querySuggestions(inputValue).then(function (suggestions) {
                             // 3. Present suggestions
                             $scope.matches = suggestions;
                         });
@@ -122,9 +128,6 @@
                             resetMatches();
                         });
                     });
-
-                    var $template = $compile(TEMPLATE)($scope);
-                    $element.after($template);
                 }
             };
         }

--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,12 @@
 {
   "name": "angular-autocomplete",
   "main": "angular-autocomplete.js",
-  "version": "0.0.2",
+  "version": "0.0.0",
   "homepage": "https://github.com/myplanetdigital/angular-autocomplete",
   "authors": [
     "Shanly Suepaul <shanly.s@myplanet.com>",
-    "Ufuk Kayserilioglu <ufuk.k@myplanet.com>"
+    "Ufuk Kayserilioglu <ufuk.k@myplanet.com>",
+    "Dongyu Su <rex.s@myplanet.com>"
   ],
   "description": "Lightweight Autocomplete for Angular",
   "moduleType": [

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-autocomplete",
   "main": "angular-autocomplete.js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/myplanetdigital/angular-autocomplete",
   "authors": [
     "Shanly Suepaul <shanly.s@myplanet.com>",


### PR DESCRIPTION
Make directive element only. This is to enforce directive modularization by decoupling it from the input element. It can theoretically be used anywhere provided it is supplied the basic data model and query callback. It also helps us modularize its styles as it is treated as a standalone component.
